### PR TITLE
Add -Wno-deprecated-register for clang

### DIFF
--- a/lib/extpp/compiler.rb
+++ b/lib/extpp/compiler.rb
@@ -86,6 +86,7 @@ module ExtPP
           else
             std = "gnu++17"
           end
+          cxx_flags = "-Wno-deprecated-register"
         end
 
         if std
@@ -96,6 +97,7 @@ module ExtPP
             std = "gnu++14"
           end
           @cxx_flags += " -std=#{std}"
+          @cxx_flags += " #{cxx_flags}" if cxx_flags
           [version, " (#{std})"]
         else
           [version, ""]


### PR DESCRIPTION
This pull-request can resolve the following warning:

```
/Users/mrkn/.rbenv/versions/2.6.0/include/ruby-2.6.0/ruby/intern.h:56:19: warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
void rb_mem_clear(register VALUE*, register long);
                  ^~~~~~~~~
```