### PR TITLE
Add [[noreturn]] to rb::State::jump()

### DIFF
--- a/include/ruby/protect.hpp
+++ b/include/ruby/protect.hpp
@@ -9,7 +9,7 @@ namespace rb {
       state_(state) {
     }
 
-    inline void jump() {
+    [[noreturn]] inline void jump() {
       rb_jump_tag(state_);
     }
 


### PR DESCRIPTION
This pull-request specifies `[[noreturn]]` attribute to `rb::State::jump()` function if the compiler supports C++1x.
This can prevent the following compiler warning on clang++.

```
/Users/mrkn/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/extpp-0.0.5/include/ruby/protect.hpp:12:24: warning: function 'jump' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
    inline void jump() {
                       ^
```