### PR TITLE
Support multi-digit clang versions

### DIFF
--- a/lib/extpp/compiler.rb
+++ b/lib/extpp/compiler.rb
@@ -78,7 +78,7 @@ module ExtPP
           else
             std = "gnu++17"
           end
-        when /\AApple LLVM version (\d+\.\d+)\.\d/
+        when /\AApple (?:LLVM|clang) version (\d+\.\d+)\.\d/
           version = Float($1)
           # TODO: Is it right?
           if version < 9.0


### PR DESCRIPTION
Installation of this gem fails on macOS Mojave (10.14.6) with the following output:

```
Building native extensions. This could take a while...
ERROR:  Error installing extpp:
        ERROR: Failed to build gem native extension.

    current directory: /Users/joshhuckabee/.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/extpp-0.0.7/ext/extpp
/Users/joshhuckabee/.rbenv/versions/2.5.5/bin/ruby -r ./siteconf20190923-96275-13lbyqp.rb extconf.rb
checking --enable-debug-build option... no
checking C++ compiler... clang++
checking g++ version... 0

# ...

In file included from /Users/joshhuckabee/.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/extpp-0.0.7/ext/extpp/protect.cpp:1:
In file included from /Users/joshhuckabee/.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/extpp-0.0.7/include/ruby.hpp:18:
In file included from /Users/joshhuckabee/.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/extpp-0.0.7/include/ruby/cast.hpp:5:
/Users/joshhuckabee/.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/extpp-0.0.7/include/ruby/object.hpp:34:12: warning: explicit conversion func
tions are a C++11 extension [-Wc++11-extensions]
    inline explicit operator bool() const {
           ^~~~~~~~
/Users/joshhuckabee/.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/extpp-0.0.7/include/ruby/object.hpp:69:34: error: no template named 'initial
izer_list' in namespace 'std'
    Object send(ID name_id, std::initializer_list<VALUE> args);
                            ~~~~~^
/Users/joshhuckabee/.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/extpp-0.0.7/include/ruby/object.hpp:71:47: error: no template named 'initial
izer_list' in namespace 'std'
    inline Object send(const char *name, std::initializer_list<VALUE> args) {

# ...

```

When running `clang++ --version` I get the following:

```
Apple clang version 11.0.0 (clang-1100.0.33.8)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

This PR is an attempt at correcting the problem that seems to work for me.