### PR TITLE
Better Mac OSX support

### DIFF
--- a/lib/extpp/compiler.rb
+++ b/lib/extpp/compiler.rb
@@ -69,7 +69,7 @@ module ExtPP
           else
             std = "gnu++17"
           end
-        when /\A.+ clang version (\d\.\d)\.\d/
+        when /\A.*clang version (\d\.\d)\.\d/
           version = Float($1)
           if version < 3.5
             std = "gnu++11"


### PR DESCRIPTION
Installing 0.0.8 on Mac OSX with:

```
$ clang++ --version
clang version 3.9.1 (tags/RELEASE_391/final)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /usr/local/bin
```

Produces the following error:

```
Building native extensions. This could take a while...
ERROR:  Error installing extpp:
	ERROR: Failed to build gem native extension.

    current directory: /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp
/Users/ajn/.rbenv/versions/2.7.1/bin/ruby -I /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/2.7.0 -r ./siteconf20201102-5509-1e6ru1s.rb extconf.rb
checking --enable-debug-build option... no
checking C++ compiler... clang++
checking g++ version... 0

current directory: /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp
make "DESTDIR=" clean
rm -rf /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp/protect.o /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp/object.o /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp/function.o /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp/class.o libruby-extpp.dylib

current directory: /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp
make "DESTDIR="
clang++ -I/Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/include 	-I/Users/ajn/.rbenv/versions/2.7.1/include/ruby-2.7.0 	-I/Users/ajn/.rbenv/versions/2.7.1/include/ruby-2.7.0/x86_64-darwin18 -I/Users/ajn/.rbenv/versions/2.7.1/include -I/usr/local/opt/libffi/include -I/usr/local/opt/readline/include -I/usr/local/opt/openssl@1.1/include -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -D_DARWIN_UNLIMITED_SELECT -D_REENTRANT   -DRB_EXTPP_COMPILATION -fno-common -g -O2 -o /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp/protect.o -c /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp/protect.cpp
In file included from /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/ext/extpp/protect.cpp:1:
In file included from /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/include/ruby.hpp:18:
In file included from /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/include/ruby/cast.hpp:5:
In file included from /Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/include/ruby/object.hpp:3:
/Users/ajn/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/extpp-0.0.8/include/ruby/type.hpp:6:21: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  using RawMethod = VALUE (*)(ANYARGS);

 ### [CUT] ###
```

It appears the clang version detection pattern has extra whitespace at the beginning preventing detection of this version.

```diff
           else
             std = "gnu++17"
           end
-        when /\A.+ clang version (\d\.\d)\.\d/
+        when /\A.*clang version (\d\.\d)\.\d/
           version = Float($1)
           if version < 3.5
             std = "gnu++11"
```

This change allows me to install/run tests locally and shouldn't affect the next pattern.

